### PR TITLE
Add Protocol Option

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,10 +26,11 @@ function Mysqldump(database, options) {
     port: options.port || 3306,
     user: options.user || process.env.USER || 'root',
     password: options.password || false,
-    gzip: options.gzip || false
+    gzip: options.gzip || false,
+    protocol: options.protocol || 'socket'
   }
   this.dump = this.start = this.run = this.make = function() {
-    var params = ['-h', opts.host,'-P', opts.port, '-u', opts.user];
+    var params = ['-h', opts.host,'-P', opts.port, '-u', opts.user, '--protocol=' + opts.protocol];
     var gzip;
     if(opts.password !== false) {
       params = params.concat(['-p'+opts.password]);


### PR DESCRIPTION
The mysql client defaults to connecting via a socket (see: http://bugs.mysql.com/bug.php?id=58811). This pull request adds a protocol option that allows the protocol to be specified as follows (from `mysqldump --help`):

 `--protocol=name     The protocol to use for connection (tcp, socket, pipe,
                      memory).`
